### PR TITLE
Result must be a Dictionary

### DIFF
--- a/custom_components/argon40/services.yaml
+++ b/custom_components/argon40/services.yaml
@@ -4,11 +4,11 @@ set_fan_speed:
   fields:
     speed:
       description: Speed
-      example: 50
+      example: "speed: 50"
 
 set_mode:
   description: Enable or disable the Always ON mode.
   fields:
     always_on:
       description: "true to enable Always ON mode, false to set the default"
-      example: true
+      example: "always_on: true"


### PR DESCRIPTION
Otherwise error:
"Failed to call service argon40.set_fan_speed. Error rendering data template: Result is not a Dictionary"