### PR TITLE
2025.5 fixes

### DIFF
--- a/custom_components/argon40/manifest.json
+++ b/custom_components/argon40/manifest.json
@@ -9,5 +9,5 @@
     "RPi.GPIO==0.7.1",
     "smbus-cffi==0.5.1"
   ],
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,7 +1,6 @@
 {
     "name": "Argon40",
-    "homeassistant": "0.110.0",
-    "render_readme": true,
+    "homeassistant": "2025.1",
     "zip_release": true,
     "filename": "argon40.zip"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated compatibility to require Home Assistant version 2025.1 or newer.
  - Incremented component version to 0.0.6.
  - Removed unused configuration field from settings.

- **Refactor**
  - Improved internal type annotations for service handlers and setup functions.
  - Disabled GPIO event detection logic for the shutdown pin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->